### PR TITLE
feat - Handle introduced A2S_INFO challenge 

### DIFF
--- a/challenge.go
+++ b/challenge.go
@@ -12,12 +12,8 @@ var (
 	ErrBadChallengeResponse = errors.New("Bad challenge response")
 )
 
-func (c *Client) getChallenge(header byte, fullResult byte) ([]byte, bool, error) {
-	if err := c.send([]byte{
-		0xff, 0xff, 0xff, 0xff,
-		header,
-		0xff, 0xff, 0xff, 0xff,
-	}); err != nil {
+func (c *Client) getChallenge(header []byte, fullResult byte) ([]byte, bool, error) {
+	if err := c.send(header); err != nil {
 		return nil, false, err
 	}
 
@@ -32,7 +28,6 @@ func (c *Client) getChallenge(header byte, fullResult byte) ([]byte, bool, error
 	switch int32(reader.ReadUint32()) {
 	case -2:
 		// We received an unexpected full reply
-
 		return data, true, nil
 	case -1:
 		// Continue

--- a/info.go
+++ b/info.go
@@ -2,7 +2,6 @@ package a2s
 
 import (
 	"errors"
-	"fmt"
 )
 
 const (
@@ -146,7 +145,6 @@ func (c *Client) QueryInfo() (*ServerInfo, error) {
 
 	header := reader.ReadUint8()
 	if header != A2S_INFO_RESPONSE {
-		fmt.Println(4, header)
 		return nil, ErrUnsupportedHeader
 	}
 

--- a/info.go
+++ b/info.go
@@ -1,9 +1,13 @@
 package a2s
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 const (
-	A2S_INFO_HEADER = 0x49 // Source & up
+	A2S_INFO_REQUEST  = 0x54
+	A2S_INFO_RESPONSE = 0x49 // Source & up
 )
 
 var (
@@ -103,19 +107,28 @@ func (c *Client) QueryInfo() (*ServerInfo, error) {
 
 	*/
 	builder.WriteBytes([]byte{
-		0xff, 0xff, 0xff, 0xff, 0x54,
+		0xFF, 0xFF, 0xFF, 0xFF, A2S_INFO_REQUEST,
 	})
 
 	builder.WriteCString("Source Engine Query")
 
-	if err := c.send(builder.Bytes()); err != nil {
-		return nil, err
-	}
-
-	data, err := c.receive()
+	data, immediate, err := c.getChallenge(builder.Bytes(), A2S_INFO_RESPONSE)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if !immediate {
+		builder.WriteBytes(data)
+		if err := c.send(builder.Bytes()); err != nil {
+			return nil, err
+		}
+
+		data, err = c.receive()
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	/*
@@ -131,7 +144,9 @@ func (c *Client) QueryInfo() (*ServerInfo, error) {
 
 	info := &ServerInfo{}
 
-	if reader.ReadUint8() != A2S_INFO_HEADER {
+	header := reader.ReadUint8()
+	if header != A2S_INFO_RESPONSE {
+		fmt.Println(4, header)
 		return nil, ErrUnsupportedHeader
 	}
 

--- a/player.go
+++ b/player.go
@@ -66,7 +66,8 @@ func (c *Client) QueryPlayer() (*PlayerInfo, error) {
 		FF FF FF FF 55 4B A1 D5 22                         ÿÿÿÿUÿÿÿÿ"
 	*/
 
-	data, immediate, err := c.getChallenge(A2S_PLAYER_REQUEST, A2S_PLAYER_RESPONSE)
+	playerRequest := []byte{0xFF, 0xFF, 0xFF, 0xFF, A2S_PLAYER_REQUEST, 0xFF, 0xFF, 0xFF, 0xFF}
+	data, immediate, err := c.getChallenge(playerRequest, A2S_PLAYER_RESPONSE)
 
 	if err != nil {
 		return nil, err

--- a/rules.go
+++ b/rules.go
@@ -43,7 +43,8 @@ func (c *Client) QueryRules() (*RulesInfo, error) {
 		FF FF FF FF 56 4B A1 D5 22                         ÿÿÿÿVK¡Õ"
 	*/
 
-	data, immediate, err := c.getChallenge(A2S_RULES_REQUEST, A2S_RULES_RESPONSE)
+	ruleRequest := []byte{0xFF, 0xFF, 0xFF, 0xFF, A2S_RULES_REQUEST, 0xFF, 0xFF, 0xFF, 0xFF}
+	data, immediate, err := c.getChallenge(ruleRequest, A2S_RULES_RESPONSE)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Update QueryInfo() to send a challenge if the initial request requires one. I'm unsure how to test this deterministically. According to the Valve developer portal, servers don't always respond with S2C_CHALLENGE:

```
...Instead, the server may reply with a challenge to the client using S2C_CHALLENGE ('A' or 0x41)...
```

I ran into the issue querying a Valheim server on the latest linux steamcmd. These changes made QueryInfo() work agin.