### PR TITLE
Fix Index out of Range in QueryPlayers()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Test binary, build with `go test -c`
 *.test
+testdata/**
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.15
+  - 1.19
   - tip
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ matrix:
 
 script:
   - go test
+  - go test -run FuzzParsePlayerInfo -fuzz FuzzParsePlayerInfo -fuzztime 1m

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/rumblefrog/go-a2s
+
+go 1.19
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/info_test.go
+++ b/info_test.go
@@ -2,23 +2,20 @@ package a2s
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"testing"
 )
 
-const (
-	TestHost = "s1.zhenyangli.me"
-)
+var testHost = flag.String("test-host", "s1.zhenyangli.me", "Remote hostname to use for unit tests.")
 
 func TestInfo(t *testing.T) {
-	c, err := NewClient(TestHost)
-
-	defer c.Close()
-
+	c, err := NewClient(*testHost)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	defer c.Close()
 
 	i, err := c.QueryInfo()
 

--- a/packet.go
+++ b/packet.go
@@ -79,6 +79,13 @@ func (r *PacketReader) ReadUint8() uint8 {
 	return b
 }
 
+func (r *PacketReader) TryReadUint8() (uint8, bool) {
+	if r.CanRead(1) != nil {
+		return 0, false
+	}
+	return r.ReadUint8(), true
+}
+
 func (r *PacketReader) ReadUint16() uint16 {
 	u16 := binary.LittleEndian.Uint16(r.buffer[r.pos:])
 	r.pos += 2
@@ -91,8 +98,22 @@ func (r *PacketReader) ReadUint32() uint32 {
 	return u32
 }
 
+func (r *PacketReader) TryReadUint32() (uint32, bool) {
+	if r.CanRead(4) != nil {
+		return 0, false
+	}
+	return r.ReadUint32(), true
+}
+
 func (r *PacketReader) ReadInt32() int32 {
 	return int32(r.ReadUint32())
+}
+
+func (r *PacketReader) TryReadInt32() (int32, bool) {
+	if r.CanRead(4) != nil {
+		return 0, false
+	}
+	return r.ReadInt32(), true
 }
 
 func (r *PacketReader) ReadUint64() uint64 {
@@ -105,6 +126,13 @@ func (r *PacketReader) ReadFloat32() float32 {
 	bits := r.ReadUint32()
 
 	return math.Float32frombits(bits)
+}
+
+func (r *PacketReader) TryReadFloat32() (float32, bool) {
+	if r.CanRead(4) != nil {
+		return 0, false
+	}
+	return r.ReadFloat32(), true
 }
 
 func (r *PacketReader) TryReadString() (string, bool) {

--- a/player_test.go
+++ b/player_test.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPlayer(t *testing.T) {
-	c, err := NewClient(TestHost)
-
-	defer c.Close()
-
+	c, err := NewClient(*testHost)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	defer c.Close()
 
 	p, err := c.QueryPlayer()
 
@@ -26,4 +26,58 @@ func TestPlayer(t *testing.T) {
 	JSON, _ := json.Marshal(p)
 
 	fmt.Println(string(JSON))
+}
+
+// Example response from https://developer.valvesoftware.com/wiki/Server_queries#Response_Format_2
+func validPlayerInfoPacket() []byte {
+	return []byte{
+		0xFF, 0xFF, 0xFF, 0xFF, 0x44, 0x02, 0x01, 0x5B, 0x44, 0x5D, 0x2D, 0x2D, 0x2D, 0x2D, 0x3E, 0x54,
+		0x2E, 0x4E, 0x2E, 0x57, 0x3C, 0x2D, 0x2D, 0x2D, 0x2D, 0x00, 0x0E, 0x00, 0x00, 0x00, 0xB4, 0x97,
+		0x00, 0x44, 0x02, 0x4B, 0x69, 0x6C, 0x6C, 0x65, 0x72, 0x20, 0x21, 0x21, 0x21, 0x00, 0x05, 0x00,
+		0x00, 0x00, 0x69, 0x24, 0xD9, 0x43,
+	}
+}
+
+func TestParsePlayerInfo(t *testing.T) {
+	c, err := NewClient(*testHost, disableDial())
+	assert.Nil(t, err, "NewClient should not return an error")
+	defer c.Close()
+
+	info, err := c.parsePlayerInfo(validPlayerInfoPacket())
+	assert.Nil(t, err, "player info should not fail for a valid packet")
+	assert.Equal(t, uint8(0x2), info.Count, "Player count should match")
+	assert.Equal(t, 2, len(info.Players), "Player count should match actual number of players parsed")
+	assert.Equal(t, uint8(1), info.Players[0].Index, "Player index should match")
+	assert.Equal(t, "[D]---->T.N.W<----", info.Players[0].Name, "Player name should match")
+	assert.Equal(t, float32(514.37036), info.Players[0].Duration, "Player duration should match")
+	assert.Equal(t, uint32(14), info.Players[0].Score, "Player score should match")
+	assert.Equal(t, uint8(2), info.Players[1].Index, "Player index should match")
+	assert.Equal(t, "Killer !!!", info.Players[1].Name, "Player name should match")
+	assert.Equal(t, float32(434.28445), info.Players[1].Duration, "Player duration should match")
+	assert.Equal(t, uint32(5), info.Players[1].Score, "Player score should match")
+}
+
+func FuzzParsePlayerInfo(f *testing.F) {
+
+	validPacket := validPlayerInfoPacket()
+
+	// seed corpus from a valid packet
+	for i := 0; i < len(validPacket); i++ {
+		f.Add(validPacket[i:], int32(0))
+		f.Add(validPacket[:i], int32(0))
+		f.Add(validPacket[i:], int32(App_TheShip))
+		f.Add(validPacket[:i], int32(App_TheShip))
+	}
+
+	f.Fuzz(func(t *testing.T, a []byte, appId int32) {
+		c, err := NewClient(*testHost, SetAppID(appId), disableDial())
+		assert.Nil(f, err, "NewClient should not return an error")
+		defer c.Close()
+		_, err = c.parsePlayerInfo(a)
+		// sometimes the fuzzer can actually generate valid player info, if so, skip since we are only checking for panics when an invalid packet is returned from a server
+		if err == nil {
+			t.Skip()
+		}
+		assert.NotNil(t, err, "invalid parsePlayerInfo fuzzing should return an error")
+	})
 }

--- a/rules_test.go
+++ b/rules_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRules(t *testing.T) {
-	c, err := NewClient(TestHost)
+	c, err := NewClient(*testHost)
 
 	defer c.Close()
 


### PR DESCRIPTION
This PR should fix the issues mentioned in https://github.com/rumblefrog/go-a2s/issues/8. I also made some additional changes outlined below.

### Additonal Changes

- Update to go 1.19
- Add Go Modules, with a dependency on https://github.com/stretchr/testify
- Unit Test remote host is now a flag, `test-host`.
- Add non-exported option to prevent dialing the above test-host for the client. Fuzz tests will cause a UDP storm otherwise.
- Add fuzz tests. These need to be run separately from `go test`.
```
➜  marcin@hive go-a2s git:(master) go test -run FuzzParsePlayerInfo -fuzz FuzzParsePlayerInfo -fuzztime 1m     
fuzz: elapsed: 0s, gathering baseline coverage: 0/232 completed
fuzz: elapsed: 0s, gathering baseline coverage: 232/232 completed, now fuzzing with 24 workers
fuzz: elapsed: 3s, execs: 631703 (210548/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 6s, execs: 1390831 (252978/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 9s, execs: 2166189 (258514/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 12s, execs: 2939420 (257733/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 15s, execs: 3706793 (255822/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 18s, execs: 4467026 (253365/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 21s, execs: 5231794 (254942/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 24s, execs: 6001452 (256567/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 27s, execs: 6769540 (256026/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 30s, execs: 7530532 (253620/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 33s, execs: 8304380 (258015/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 36s, execs: 9066076 (253856/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 39s, execs: 9842515 (258786/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 42s, execs: 10605470 (254377/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 45s, execs: 11364872 (253105/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 48s, execs: 12133514 (256235/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 51s, execs: 12899618 (255320/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 54s, execs: 13654329 (251574/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 57s, execs: 14413669 (253142/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 1m0s, execs: 15180401 (255467/sec), new interesting: 0 (total: 232)
fuzz: elapsed: 1m0s, execs: 15180401 (0/sec), new interesting: 0 (total: 232)
PASS
ok      github.com/rumblefrog/go-a2s    60.116s
```

### Commits

commit 6ba9f84466abd24286e787383de34ec50fe8a4b5
Author: Marcin Pawlowski <github@marcin.io>
Date:   Mon Dec 12 16:13:14 2022 -0800

    cleanup some errors

commit 49bc058b27911639ce154267f32e087f92a8adc8
Author: Marcin Pawlowski <github@marcin.io>
Date:   Mon Dec 12 16:07:53 2022 -0800

    clean up errors

commit ba93af67a2e2e8c6e660be3077f18f2837fb6335
Author: Marcin Pawlowski <github@marcin.io>
Date:   Mon Dec 12 15:43:26 2022 -0800

    fix player-info panics